### PR TITLE
set CKA_TOKEN to TRUE

### DIFF
--- a/src/bin/p11speed.cpp
+++ b/src/bin/p11speed.cpp
@@ -632,7 +632,7 @@ int generateRsa(CK_SESSION_HANDLE hSession, CK_ULONG keysize, CK_OBJECT_HANDLE &
 		{ CKA_VERIFY,          &bTrue,    sizeof(bTrue)   },
 		{ CKA_ENCRYPT,         &bFalse,   sizeof(bFalse)  },
 		{ CKA_WRAP,            &bFalse,   sizeof(bFalse)  },
-		{ CKA_TOKEN,           &bFalse,   sizeof(bFalse)  },
+		{ CKA_TOKEN,           &bTrue,    sizeof(bTrue)  },
 		{ CKA_MODULUS_BITS,    &keysize,  sizeof(keysize) },
 		{ CKA_PUBLIC_EXPONENT, &pubExp,   sizeof(pubExp)  }
 	};
@@ -645,7 +645,7 @@ int generateRsa(CK_SESSION_HANDLE hSession, CK_ULONG keysize, CK_OBJECT_HANDLE &
 		{ CKA_DECRYPT,     &bFalse,   sizeof(bFalse)  },
 		{ CKA_UNWRAP,      &bFalse,   sizeof(bFalse)  },
 		{ CKA_SENSITIVE,   &bTrue,    sizeof(bTrue)   },
-		{ CKA_TOKEN,       &bFalse,   sizeof(bFalse)  },
+		{ CKA_TOKEN,       &bTrue,    sizeof(bTrue)  },
 		{ CKA_PRIVATE,     &bTrue,    sizeof(bTrue)   },
 		{ CKA_EXTRACTABLE, &bFalse,   sizeof(bFalse)  }
 	};
@@ -699,7 +699,7 @@ int generateDsa(CK_SESSION_HANDLE hSession, CK_ULONG keysize, CK_OBJECT_HANDLE &
 		{ CKA_VERIFY,   &bTrue,    sizeof(bTrue)   },
 		{ CKA_ENCRYPT,  &bFalse,   sizeof(bFalse)  },
 		{ CKA_WRAP,     &bFalse,   sizeof(bFalse)  },
-		{ CKA_TOKEN,    &bFalse,   sizeof(bFalse)  }
+		{ CKA_TOKEN,    &bTrue,    sizeof(bTrue)   }
 	};
 
 	CK_ATTRIBUTE prkAttribs[] = {
@@ -710,7 +710,7 @@ int generateDsa(CK_SESSION_HANDLE hSession, CK_ULONG keysize, CK_OBJECT_HANDLE &
 		{ CKA_DECRYPT,     &bFalse,   sizeof(bFalse)  },
 		{ CKA_UNWRAP,      &bFalse,   sizeof(bFalse)  },
 		{ CKA_SENSITIVE,   &bTrue,    sizeof(bTrue)   },
-		{ CKA_TOKEN,       &bFalse,   sizeof(bFalse)  },
+		{ CKA_TOKEN,       &bTrue,    sizeof(bTrue)   },
 		{ CKA_PRIVATE,     &bTrue,    sizeof(bTrue)   },
 		{ CKA_EXTRACTABLE, &bFalse,   sizeof(bFalse)  }
 	};
@@ -781,7 +781,7 @@ int generateEcdsa(CK_SESSION_HANDLE hSession, CK_ULONG keysize, CK_OBJECT_HANDLE
 		{ CKA_VERIFY,    &bTrue,    sizeof(bTrue)   },
 		{ CKA_ENCRYPT,   &bFalse,   sizeof(bFalse)  },
 		{ CKA_WRAP,      &bFalse,   sizeof(bFalse)  },
-		{ CKA_TOKEN,     &bFalse,   sizeof(bFalse)  }
+		{ CKA_TOKEN,     &bTrue,    sizeof(bTrue)   }
 	};
 
 	CK_ATTRIBUTE prkAttribs[] = {
@@ -792,7 +792,7 @@ int generateEcdsa(CK_SESSION_HANDLE hSession, CK_ULONG keysize, CK_OBJECT_HANDLE
 		{ CKA_DECRYPT,     &bFalse,   sizeof(bFalse)  },
 		{ CKA_UNWRAP,      &bFalse,   sizeof(bFalse)  },
 		{ CKA_SENSITIVE,   &bTrue,    sizeof(bTrue)   },
-		{ CKA_TOKEN,       &bFalse,   sizeof(bFalse)  },
+		{ CKA_TOKEN,       &bTrue,    sizeof(bTrue)   },
 		{ CKA_PRIVATE,     &bTrue,    sizeof(bTrue)   },
 		{ CKA_EXTRACTABLE, &bFalse,   sizeof(bFalse)  }
 	};
@@ -851,7 +851,7 @@ int generateGost(CK_SESSION_HANDLE hSession, CK_OBJECT_HANDLE &hPuk, CK_OBJECT_H
 		{ CKA_VERIFY,           &bTrue,    sizeof(bTrue)   },
 		{ CKA_ENCRYPT,          &bFalse,   sizeof(bFalse)  },
 		{ CKA_WRAP,             &bFalse,   sizeof(bFalse)  },
-		{ CKA_TOKEN,            &bFalse,   sizeof(bFalse)  }
+		{ CKA_TOKEN,            &bTrue,    sizeof(bTrue)   }
 	};
 
 	CK_ATTRIBUTE prkAttribs[] = {
@@ -862,7 +862,7 @@ int generateGost(CK_SESSION_HANDLE hSession, CK_OBJECT_HANDLE &hPuk, CK_OBJECT_H
 		{ CKA_DECRYPT,     &bFalse,   sizeof(bFalse)  },
 		{ CKA_UNWRAP,      &bFalse,   sizeof(bFalse)  },
 		{ CKA_SENSITIVE,   &bTrue,    sizeof(bTrue)   },
-		{ CKA_TOKEN,       &bFalse,   sizeof(bFalse)  },
+		{ CKA_TOKEN,       &bTrue,    sizeof(bTrue)   },
 		{ CKA_PRIVATE,     &bTrue,    sizeof(bTrue)   },
 		{ CKA_EXTRACTABLE, &bFalse,   sizeof(bFalse)  }
 	};

--- a/src/bin/p11speed.cpp
+++ b/src/bin/p11speed.cpp
@@ -632,7 +632,7 @@ int generateRsa(CK_SESSION_HANDLE hSession, CK_ULONG keysize, CK_OBJECT_HANDLE &
 		{ CKA_VERIFY,          &bTrue,    sizeof(bTrue)   },
 		{ CKA_ENCRYPT,         &bFalse,   sizeof(bFalse)  },
 		{ CKA_WRAP,            &bFalse,   sizeof(bFalse)  },
-		{ CKA_TOKEN,           &bTrue,    sizeof(bTrue)  },
+		{ CKA_TOKEN,           &bTrue,    sizeof(bTrue)   },
 		{ CKA_MODULUS_BITS,    &keysize,  sizeof(keysize) },
 		{ CKA_PUBLIC_EXPONENT, &pubExp,   sizeof(pubExp)  }
 	};
@@ -645,7 +645,7 @@ int generateRsa(CK_SESSION_HANDLE hSession, CK_ULONG keysize, CK_OBJECT_HANDLE &
 		{ CKA_DECRYPT,     &bFalse,   sizeof(bFalse)  },
 		{ CKA_UNWRAP,      &bFalse,   sizeof(bFalse)  },
 		{ CKA_SENSITIVE,   &bTrue,    sizeof(bTrue)   },
-		{ CKA_TOKEN,       &bTrue,    sizeof(bTrue)  },
+		{ CKA_TOKEN,       &bTrue,    sizeof(bTrue)   },
 		{ CKA_PRIVATE,     &bTrue,    sizeof(bTrue)   },
 		{ CKA_EXTRACTABLE, &bFalse,   sizeof(bFalse)  }
 	};


### PR DESCRIPTION
If we're going to test the performance of the HSM, we better make sure the keys are on the token.
